### PR TITLE
1 datapack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ ansible-galaxy role install aurxl.minecraft
 It is also possible to install a [fabric](https://fabricmc.net/) server in order to play with mods enabled.
 See example [Fabric](#fabric) config below.
 
+### Datapacks
+Install local saved datapacks or provide a download link to install datapacks to your Minecraft server.
+Have a look at [Datapacks](#datapacks) example config.
 
 ## Options
 #### General Server Options:
@@ -65,6 +68,12 @@ See example [Fabric](#fabric) config below.
 - `server_properties` (dict): Set the usual options from `server.properties` file
   - Default: Default `server.properties`
   - Note, that `-` and `.` **must** be replaced by `_`
+- `datapacks` (list): A list of datapacks to be installed
+  - default: []
+  - Upload local file (`file`)
+  - Download datapack (`url`)
+    - optionally provide a checksum (`checksum`)
+      - `<sha>:<checksum>`
 
 #### Fabric server options
 - `fabric` (dict): Install Fabric server
@@ -83,7 +92,6 @@ See example [Fabric](#fabric) config below.
     - `name`: file name
     - `content`: content of the config file
     - `path`: local path of a config file
-
 
 ### Find my mod version id on modrinth
 
@@ -195,3 +203,16 @@ minecraft:
   min_mem: 2
   max_mem: 4
 ```
+
+### Datapcks
+``` yaml
+minecraft:
+  version: latest
+  eula: true
+
+  datapacks:
+    - url: https://cdn.modrinth.com/data/.../FOO.zip
+      checksum: sha256:Ch3CksUm
+    - file: files/datapack.zip
+```
+

--- a/tasks/datapacks.yml
+++ b/tasks/datapacks.yml
@@ -1,0 +1,30 @@
+---
+- name: Directory world/datapacks is present
+  become: true
+  ansible.builtin.file:
+    path: "{{ minecraft.path }}/world/datapacks"
+    owner: "{{ minecraft_user_name }}"
+    group: "{{ minecraft_user_name }}"
+    mode: u=rwx,g=rwx,o=rw
+    state: directory
+
+- name: Copy local datapack
+  become: true
+  ansible.builtin.copy:
+    src: "{{ datapack.file }}"
+    dest: "{{ minecraft.path }}/world/datapacks/"
+    owner: "{{ minecraft_user_name }}"
+    group: "{{ minecraft_user_name }}"
+    mode: u=rw,g=rw,o=r
+  when: datapack.file is defined
+
+- name: Download datapack
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ datapack.url }}"
+    dest: "{{ minecraft.path }}/world/datapacks/"
+    checksum: "{{ datapack.checksum | default('') }}"
+    owner: "{{ minecraft_user_name }}"
+    group: "{{ minecraft_user_name }}"
+    mode: u=rw,g=rw,o=r
+  when: datapack.url is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,3 +47,10 @@
 - name: Include Minecraft fabric server stuff
   ansible.builtin.include_tasks: fabric/minecraft-server-fabric.yml
   when: minecraft.fabric.enabled
+
+- name: Include Minecraft datapacks installation
+  ansible.builtin.include_tasks: datapacks.yml
+  loop: "{{ minecraft.datapacks | default([]) }}"
+  loop_control:
+    loop_var: "datapack"
+


### PR DESCRIPTION

> # [Feature] Datapack support
> ## user story
> 
>     * Allow to add datapacks
>       
>       * Download datapacks via provided link
>       * upload datapack from local src
> 
> 
> ## implementation
> 
>     * [x]  copy datapacks to `/opt/minecraft-server/world/datapacks`
>       
>       * [ ]  checksum check: pre upload == uploaded file
> 
>     * [x]  download datapacks from dowload url
>       
>       * [x]  checksum match!
>         
>         * [x]  so checksum has to be provided in host_var
>         * [ ]  **or** checksum check can **optionally** be disabled
> 
>     * [x]  trigger reinstallation of datapacks when world was deleted
> 
> 
> ## open questions
> 
>     * consistency check for datapacks specified in host_var with actually present files
>       
>       * -> maybe new Feature for consistency checks in general (for mods, datapacks, worlds ...)